### PR TITLE
Style pass on the FCB1010 post

### DIFF
--- a/blog/fcb1010-biasfx2/index.html
+++ b/blog/fcb1010-biasfx2/index.html
@@ -2,7 +2,20 @@
 <html><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Again</title>
+<title>How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Guitar Again</title>
+<meta name="description" content="The MIDI pedalboard that collected dust for years finally gave up last weekend. I've been galloping through Iron Maiden ever since.">
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="Mahmoud Saada">
+<meta property="og:title" content="How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Guitar Again">
+<meta property="og:description" content="The MIDI pedalboard that collected dust for years finally gave up last weekend. I've been galloping through Iron Maiden ever since.">
+<meta property="og:url" content="https://saada.github.io/blog/fcb1010-biasfx2/">
+<meta property="og:image" content="https://saada.github.io/blog/fcb1010-biasfx2/images/og-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Guitar Again">
+<meta name="twitter:description" content="The MIDI pedalboard that collected dust for years finally gave up last weekend. I've been galloping through Iron Maiden ever since.">
+<meta name="twitter:image" content="https://saada.github.io/blog/fcb1010-biasfx2/images/og-card.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <style>
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Vollkorn:ital,wght@0,400;0,600;0,700;0,900;1,400&display=swap");
@@ -101,7 +114,7 @@ footer a:hover { color:var(--accent) }
     </div>
     <div class="terminal__body">
       <div class="prompt">cat fcb1010-biasfx2.md</div>
-      <h1>How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Again</h1>
+      <h1>How Claude's Fable Model Saved My Gear and Got Me Excited About Playing Guitar Again</h1>
       <div class="subtitle">The MIDI pedalboard that collected dust for years finally gave up last weekend. I've been galloping through Iron Maiden ever since.<span class="cursor">▋</span></div>
     </div>
   </header>
@@ -112,6 +125,7 @@ footer a:hover { color:var(--accent) }
 <p>The dream was always simple: stomp a switch, get the Comfortably Numb solo tone. Stomp another, Purple Rain cleans. Rock the expression pedal, wah. And the real dream, the one that kept me dragging this thing back out: playing my Iron Maiden repertoire properly. Seventh Son harmonies, The Wicker Man gallop, both Murray <em>and</em> Smith parts coming out of one guitar, hands never leaving the strings. The reality was a pedalboard from 2004 and an amp sim from this decade, BIAS FX 2, that flatly refuse to understand each other out of the box.</p>
 <p>Skill issues? Sure. But gosh, are these two complicated to wire together.</p>
 <h2>Why everyone gives up on the FCB1010</h2>
+<p>Hey FCB1010, we need to talk.</p>
 <p><img alt="The Behringer FCB1010" src="images/fcb1010-product.jpg" />
 <em>Ten switches, two expression pedals, one two-digit display, infinite menu-diving. (photo: <a href="https://www.sweetwater.com/store/detail/FCB1010--behringer-midi-foot-controller-fcb1010">Sweetwater</a>)</em></p>
 <p>Press one switch on a factory-fresh FCB1010 and it doesn't send a MIDI message. It sends <strong>seven</strong>: five Program Changes and two Control Changes, on multiple channels, all at once. BIAS FX 2's MIDI Learn dutifully grabs whichever of the seven arrives first. Congratulations: your delay toggle is now mapped to garbage.</p>
@@ -138,10 +152,10 @@ TOGGLES = [
 <ol>
 <li>In global config mode you <strong>tap</strong> UP to change pages. Holding it does nothing. I held it for a very long time.</li>
 <li>After the transfer, you must hold DOWN to <em>save</em>. Skip it and the pedal politely discards everything. I skipped it. Twice.</li>
-<li>Cheap USB-MIDI cables are pathological liars. <a href="https://www.amazon.com/dp/B0F9DVH9MM">Mine</a> passes normal 3-byte MIDI perfectly, then silently eats SysEx, and only in one direction. Pedal-to-Mac dumps vanish into the void; Mac-to-pedal uploads work fine. A MIDI monitor showing traffic proves nothing about SysEx. The only real test is counting bytes.</li>
+<li>Cheap USB-MIDI cables are pathological liars. <a href="https://www.amazon.com/dp/B0F9DVH9MM">Mine</a> passes normal 3-byte MIDI perfectly, then silently eats SysEx, and only in one direction. Pedal-to-Mac dumps vanish into the void; Mac-to-pedal uploads work fine. I spent a whole evening blaming my own code before a packet capture pointed at the cable. A MIDI monitor showing traffic proves nothing about SysEx. The only real test is counting bytes.</li>
 </ol>
 <h2>BIAS FX 2 has no API. It has something better.</h2>
-<p>The other half of the problem: BIAS FX 2 has no scripting interface, no import format, no automation story at all. What it does have is a data directory full of plain JSON, and nobody stopping you from reading it.</p>
+<p>You might be thinking: "Okay, so the pedal side is code now. But BIAS FX 2 has no scripting interface, no import format, no automation story at all. Now what?" I'm glad you asked. What BIAS FX 2 does have is a data directory full of plain JSON, and nobody stopping you from reading it.</p>
 <p>A few evenings of spelunking later, the whole map:</p>
 <ul>
 <li><code>midi.json</code>: global mappings. Maps Program Change numbers to preset UUIDs, plus app-level actions like the tuner (<code>utility.tuner</code>).</li>
@@ -166,7 +180,7 @@ TOGGLES = [
 <p>Stomp switch 1: Gilmour. Stomp 4 on bank 1: Nevermind. It has worked every single time since, which for this pedalboard is a personal record.</p>
 <p><img alt="Sterling by Music Man JP70, Stealth Black" src="images/jp70.jpg" />
 <em>The guitar on the other end of all this: my <a href="https://www.guitarcenter.com/Sterling-by-Music-Man/John-Petrucci-JP70-7-String-Electric-Guitar-Stealth-Black-1358268440958.gc">Sterling by Music Man John Petrucci JP70</a>. Seven strings, stealth black, equally happy playing Petrucci or pretending to be two Iron Maidens at once.</em></p>
-<p>But bank 2, switch 1. That's the one. JCM-style crunch, and on switch 7 sits a harmonizer wired for 3rds. I hit it, played the lead from The Evil That Men Do, and both harmony parts came out of my JP70 at once. I am not exaggerating when I say I stood in my living room grinning like an idiot. Twenty minutes later I had galloped through half of Seventh Son of a Seventh Son, kicked the wah on for a solo without thinking about MIDI even once, and ridden the volume pedal into the Moonchild intro like the last several years of dust never happened. This is what the pedalboard was <em>for</em>. I'd just never met it before.</p>
+<p>But bank 2, switch 1. That's the one. JCM-style crunch, and on switch 7 sits a harmonizer wired for 3rds. I hit it, played the lead from The Evil That Men Do, and BOOM: both harmony parts came out of my JP70 at once. I am not exaggerating when I say I stood in my living room grinning like an idiot. Twenty minutes later I had galloped through half of Seventh Son of a Seventh Son, kicked the wah on for a solo without thinking about MIDI even once, and ridden the volume pedal into the Moonchild intro like the last several years of dust never happened. This is what the pedalboard was <em>for</em>. I'd just never met it before.</p>
 <h2>We did it</h2>
 <p>Hardware I'd written off for years now does exactly what I always wanted, because both ends turned out to be automatable: one through a 20-year-old SysEx format, the other through JSON files nobody documents.</p>
 <p>Credit where it's due: I did this whole thing pair-programming with Claude Fable, and it's the reason this post exists. I had thrown earlier AI models at this exact problem before and they'd confidently hallucinate SysEx byte layouts or tell me to "check the manual." Fable actually reverse-engineered the BIAS FX 2 file formats from my own preset library, caught its own landmines (like the bank index that makes presets invisible, or my wah stomp being globally mapped to "previous preset"), diagnosed a counterfeit MIDI cable from packet captures, and generated entire preset banks as code, both the FCB1010's memory and the BIAS FX 2 bank. Wah, octaver, volume pedal, tuner: all four working from the floor, for the first time ever, wired by a language model doing surgery on JSON files. Wild time to be alive.</p>


### PR DESCRIPTION
Four voice touches matching the older Medium posts: direct address to the pedal, an anticipated-objection transition into the BIAS FX 2 section, a BOOM at the harmonizer payoff, and the evening lost to blaming my own code instead of the cable.